### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,42 +1,48 @@
 {
-    "name": "urlgithub-object",
-    "version": "1.0.2",
-    "description": "Extract user, repo, and other interesting properties from GitHub URLs",
-    "main": "dist/commonjs.js",
-    "scripts": {
-        "test": "mocha && standard",
-        "build": "browserify index.js --standalone gh | buble > dist/gh.js; buble index.js > dist/commonjs.js",
-        "deploy": "npm run build && git subtree push --prefix dist origin gh-pages && open https://github.com/leiz95/URLgithub-object.git"
-    },
-    "website": "https://github.com/leiz95/URLgithub-object.git",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/leiz95/URLgithub-object"
-    },
-    "keywords": [
-        "github",
-        "url",
-        "repo"
-    ],
-    "author": "leiz95",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/leiz95/URLgithub-object/issues"
-    },
-    "dependencies": {
-        "is-url": "^1.1.0",
-        "markdown-expands-tab": "^1.0.2"
-    },
-    "devDependencies": {
-        "browserify": "^13.0.1",
-        "buble": "^0.15.2",
-        "mocha": "^2.5.3",
-        "standard": "^7.1.2",
-        "uglify-js": "^2.4.15"
-    },
-    "standard": {
-        "ignore": [
-            "dist"
-        ]
+  "name": "urlgithub-object",
+  "version": "1.0.2-lineaje-01",
+  "description": "Extract user, repo, and other interesting properties from GitHub URLs",
+  "main": "dist/commonjs.js",
+  "scripts": {
+    "test": "mocha && standard",
+    "build": "browserify index.js --standalone gh | buble > dist/gh.js; buble index.js > dist/commonjs.js",
+    "deploy": "npm run build && git subtree push --prefix dist origin gh-pages && open https://github.com/leiz95/URLgithub-object.git"
+  },
+  "website": "https://github.com/leiz95/URLgithub-object.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lineaje-labs-gos/urlgithub-object"
+  },
+  "keywords": [
+    "github",
+    "url",
+    "repo"
+  ],
+  "author": "leiz95",
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
     }
+  ],
+  "bugs": {
+    "url": "https://github.com/leiz95/URLgithub-object/issues"
+  },
+  "dependencies": {
+    "is-url": "^1.1.0",
+    "markdown-expands-tab": "^1.0.2"
+  },
+  "devDependencies": {
+    "browserify": "^13.0.1",
+    "buble": "^0.15.2",
+    "mocha": "^2.5.3",
+    "standard": "^7.1.2",
+    "uglify-js": "^2.4.15"
+  },
+  "standard": {
+    "ignore": [
+      "dist"
+    ]
+  }
 }


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
